### PR TITLE
Fix repo access to be at runtime for OTP releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ from Ecto.Changeset.
 
 ```elixir
 def deps do
-  [{:formex_ecto, "~> 0.2.0"}]
+  [{:formex_ecto, "~> 0.2.3"}]
 end
 ```
 

--- a/lib/builder.ex
+++ b/lib/builder.ex
@@ -4,14 +4,15 @@ defmodule Formex.BuilderType.Ecto do
 end
 
 defimpl Formex.BuilderProtocol, for: Formex.BuilderType.Ecto do
+  alias Formex.Config
   alias Formex.Form
   alias Formex.Field
   alias Formex.FormNested
   alias Formex.FormCollection
-  import Formex.Ecto.Utils
-  require Ecto.Query
 
-  @repo Application.get_env(:formex, :repo)
+  import Formex.Ecto.Utils
+
+  require Ecto.Query
 
   @spec create_form(Map.t()) :: Map.t()
   def create_form(args) do
@@ -81,7 +82,7 @@ defimpl Formex.BuilderProtocol, for: Formex.BuilderType.Ecto do
         queryable = struct.__struct__.__schema__(:association, item.name).queryable
 
         struct
-        |> @repo.preload([
+        |> Config.repo().preload([
           {item.name, Ecto.Query.from(e in queryable, order_by: e.id)}
         ])
       else

--- a/lib/changeset.ex
+++ b/lib/changeset.ex
@@ -1,11 +1,12 @@
 defmodule Formex.Ecto.Changeset do
   import Ecto.Changeset
   import Ecto.Query
+  import Formex.Ecto.Utils
+
+  alias Formex.Config
   alias Formex.Form
   alias Formex.FormCollection
   alias Formex.FormNested
-  import Formex.Ecto.Utils
-  @repo Application.get_env(:formex, :repo)
 
   @spec create_changeset(form :: Form.t()) :: Form.t()
   def create_changeset(form) do
@@ -78,7 +79,7 @@ defmodule Formex.Ecto.Changeset do
           associated =
             module.related
             |> where([c], c.id in ^ids)
-            |> @repo.all
+            |> Config.repo().all
             |> Enum.map(&Ecto.Changeset.change/1)
 
           changeset

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,0 +1,5 @@
+defmodule Formex.Config do
+  def repo do
+    Application.get_env(:formex, :repo)
+  end
+end

--- a/lib/controller.ex
+++ b/lib/controller.ex
@@ -1,9 +1,10 @@
 defmodule Formex.Ecto.Controller do
+  alias Formex.Config
   alias Formex.Form
   alias Formex.Builder
+
   import Formex.Ecto.Validator
   import Formex.Ecto.Changeset
-  @repo Application.get_env(:formex, :repo)
 
   defmacro __using__(_) do
     quote do
@@ -85,7 +86,7 @@ defmodule Formex.Ecto.Controller do
     if form.valid? do
       form
       |> create_changeset
-      |> @repo.insert
+      |> Config.repo().insert
       |> case do
         {:error, changeset} ->
           handle_changeset_error(form, changeset)
@@ -108,7 +109,7 @@ defmodule Formex.Ecto.Controller do
     if form.valid? do
       form
       |> create_changeset
-      |> @repo.update
+      |> Config.repo().update
       |> case do
         {:error, changeset} ->
           handle_changeset_error(form, changeset)

--- a/lib/custom_fields/select_assoc.ex
+++ b/lib/custom_fields/select_assoc.ex
@@ -1,10 +1,10 @@
 defmodule Formex.Ecto.CustomField.SelectAssoc do
   @behaviour Formex.CustomField
   import Ecto.Query
+
+  alias Formex.Config
   alias Formex.Field
   alias Formex.Form
-
-  @repo Application.get_env(:formex, :repo)
 
   @moduledoc """
   This module generates a `:select` field with options downloaded from Repo.
@@ -175,7 +175,7 @@ defmodule Formex.Ecto.CustomField.SelectAssoc do
 
     query
     |> apply_query(opts[:query])
-    |> @repo.all
+    |> Config.repo().all
     |> group_rows(opts[:group_by])
     |> generate_choices(opts[:choice_label])
   end
@@ -208,7 +208,7 @@ defmodule Formex.Ecto.CustomField.SelectAssoc do
     selected =
       if form.struct.id do
         form.struct
-        |> @repo.preload(name)
+        |> Config.repo().preload(name)
         |> Map.get(name)
         |> Enum.map(& &1.id)
       else
@@ -231,7 +231,7 @@ defmodule Formex.Ecto.CustomField.SelectAssoc do
           query
           |> apply_query(opts[:query])
           |> apply_group_by_assoc(opts[:group_by])
-          |> @repo.one
+          |> Config.repo().one
 
         if row do
           get_choice_label_val(row, opts[:choice_label])
@@ -244,7 +244,7 @@ defmodule Formex.Ecto.CustomField.SelectAssoc do
         module
         |> apply_query(opts[:query])
         |> apply_group_by_assoc(opts[:group_by])
-        |> @repo.all
+        |> Config.repo().all
         |> group_rows(opts[:group_by])
         |> generate_choices(opts[:choice_label])
 


### PR DESCRIPTION
## 📖 Description

Fix the various access to the `@repo` variable to make them executed at runtime instead of compile time. This avoid issues with OTP releases where the repo is `nil` when executing a request, such as this:

```
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function nil.preload/2 is undefined
        nil.preload(%Cominar.Mall{},...)
        (elixir 1.10.4) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        (formex_ecto 0.2.1) lib/builder.ex:24: Formex.BuilderProtocol.Formex.BuilderType.Ecto.create_form/1
        (formex 0.6.7) lib/formex/builder.ex:50: Formex.Builder.create_form/5
        (cominar 1.11.7) lib/cominar_web/malls/controller.ex:29: CominarWeb.Malls.Controller.edit/2
        (cominar 1.11.7) lib/cominar_web/malls/controller.ex:1: CominarWeb.Malls.Controller.action/2
        (cominar 1.11.7) lib/cominar_web/malls/controller.ex:1: CominarWeb.Malls.Controller.phoenix_controller_pipeline/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
```

## 🦀 Dispatch
		
- `#dispatch/elixir`

## 🎉 Résultat

**Before**
```
Compiling 9 files (.ex)
warning: variable "queryable" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/builder.ex:80: Formex.BuilderProtocol.Formex.BuilderType.Ecto.preload_assocs/1

warning: Cominar.Repo.insert/1 is undefined (module Cominar.Repo is not available or is yet to be defined)
  lib/controller.ex:88: Formex.Ecto.Controller.insert_form_data/1

warning: Cominar.Repo.update/1 is undefined (module Cominar.Repo is not available or is yet to be defined)
  lib/controller.ex:111: Formex.Ecto.Controller.update_form_data/1

warning: Cominar.Repo.all/1 is undefined (module Cominar.Repo is not available or is yet to be defined)
  lib/changeset.ex:62: Formex.Ecto.Changeset.cast_multiple_selects/2

warning: Cominar.Repo.all/1 is undefined (module Cominar.Repo is not available or is yet to be defined)
Found at 2 locations:
  lib/custom_fields/select_assoc.ex:178: Formex.Ecto.CustomField.SelectAssoc.search/3
  lib/custom_fields/select_assoc.ex:247: Formex.Ecto.CustomField.SelectAssoc.put_choices/2

warning: Cominar.Repo.one/1 is undefined (module Cominar.Repo is not available or is yet to be defined)
  lib/custom_fields/select_assoc.ex:234: Formex.Ecto.CustomField.SelectAssoc.put_choices/2

warning: Cominar.Repo.preload/2 is undefined (module Cominar.Repo is not available or is yet to be defined)
  lib/custom_fields/select_assoc.ex:211: Formex.Ecto.CustomField.SelectAssoc.create_field_multiple/3

Generated formex_ecto app
```

**After**
```
==> formex_ecto
Compiling 9 files (.ex)
Generated formex_ecto app
```